### PR TITLE
Fix: Update default timeout value

### DIFF
--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -86,7 +86,7 @@ class PollingFuture(base.Future):
             compatibility.
     """
 
-    _DEFAULT_VALUE = object()
+    _DEFAULT_VALUE = None
 
     def __init__(self, polling=DEFAULT_POLLING, **kwargs):
         super(PollingFuture, self).__init__()


### PR DESCRIPTION
Changed _DEFAULT_VALUE from empty object (unsupported type by downstream methods) to None (one of the expected types)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-api-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-python#15072 🦕
